### PR TITLE
Update arangodb module to use JNoSQL Database arangodb extension

### DIFF
--- a/arangodb/README.md
+++ b/arangodb/README.md
@@ -2,7 +2,7 @@
 
 ![ArangoDB Project](http://www.jnosql.org/img/logos/ArangoDB.png)
 
-A JNoSQL Artemis project with Java SE using Document API with ArangoDB as driver implementation.
+A JNoSQL project with Java SE using Document API with ArangoDB as driver implementation.
 
 
 **ArangoDB**: ArangoDB is a native multi-model database system[1] developed by triAGENS GmbH. The database system supports three important data models (key/value, documents, graphs) with one database core and a unified query language AQL (ArangoDB Query Language). The query language is declarative and allows the combination of different data access patterns in a single query. ArangoDB is a NoSQL database system but AQL is similar in many ways to SQL.
@@ -13,11 +13,16 @@ A JNoSQL Artemis project with Java SE using Document API with ArangoDB as driver
 
 Once this a communication layer to ArangoDB, we're using integration test, so you need to install ArangoDB. The recommended way is using Docker.
 
-![Docker](https://www.docker.com/sites/default/files/horizontal_large.png)
+![Docker](https://d1q6f0aelx0por.cloudfront.net/product-logos/library-docker-logo.png)
 
 
 1. Install docker: https://www.docker.com/
 1. https://hub.docker.com/r/couchbase/server/
-1. Run docker command
-1. `docker run -e ARANGO_NO_AUTH=1 -d --name arangodb-instance -p 8529:8529 -d arangodb/arangodb`
-1. Execute the test `mvn clean install`
+1. Run docker command:
+    ```console
+    docker run -e ARANGO_NO_AUTH=1 -d --name arangodb-instance -p 8529:8529 -d arangodb/arangodb
+    ```
+1. Execute the test 
+    ```console
+    mvn clean install
+    ```

--- a/arangodb/pom.xml
+++ b/arangodb/pom.xml
@@ -23,21 +23,15 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jnosql.version>1.0.0-SNAPSHOT</jnosql.version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.jnosql.mapping</groupId>
-            <artifactId>jnosql-arangodb-extension</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.eclipse.jnosql.databases</groupId>
+            <artifactId>jnosql-arangodb</artifactId>
+            <version>${jnosql.version}</version>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>sonatype.snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </repository>
-    </repositories>
 
 </project>

--- a/arangodb/src/main/java/org/jnosql/demo/se/App1.java
+++ b/arangodb/src/main/java/org/jnosql/demo/se/App1.java
@@ -12,7 +12,7 @@
 package org.jnosql.demo.se;
 
 
-import org.eclipse.jnosql.mapping.arangodb.document.ArangoDBTemplate;
+import org.eclipse.jnosql.databases.arangodb.mapping.ArangoDBTemplate;
 import org.eclipse.jnosql.communication.document.DocumentQuery;
 
 import jakarta.enterprise.inject.se.SeContainer;

--- a/arangodb/src/main/java/org/jnosql/demo/se/HeroRepository.java
+++ b/arangodb/src/main/java/org/jnosql/demo/se/HeroRepository.java
@@ -10,12 +10,14 @@
  */
 package org.jnosql.demo.se;
 
-import org.eclipse.jnosql.mapping.arangodb.document.AQL;
-import org.eclipse.jnosql.mapping.arangodb.document.ArangoDBRepository;
-import org.eclipse.jnosql.mapping.arangodb.document.Param;
+import jakarta.data.repository.Repository;
+import org.eclipse.jnosql.databases.arangodb.mapping.AQL;
+import org.eclipse.jnosql.databases.arangodb.mapping.ArangoDBRepository;
+import org.eclipse.jnosql.databases.arangodb.mapping.Param;
 
 import java.util.List;
 
+@Repository
 public interface HeroRepository extends ArangoDBRepository<Hero, String> {
 
     List<Hero> findByName(String name);

--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,7 @@
     <artifactId>mapping-demo-java-se</artifactId>
     <packaging>pom</packaging>
     <name>JNoSQL Demo</name>
-
-    <parent>
-        <groupId>org.eclipse.jnosql</groupId>
-        <artifactId>jnosql-parent</artifactId>
-        <version>1.0.0-b6</version>
-    </parent>
+    <version>1.0.0-b6</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -31,6 +26,7 @@
         <jakarta.json.bind.version>3.0.0</jakarta.json.bind.version>
         <jakarta.json.version>2.1.1</jakarta.json.version>
         <tinkerpop.version>3.6.1</tinkerpop.version>
+        <weld.se.core.version>5.1.0.Final</weld.se.core.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Ref.: https://github.com/eclipse/jnosql/issues/365
## Changes
- Update REAME.md from arangodb module;
- Removed unnecessary dependencies from project parent pom;
- Update arangodb module to use JNoSQL Database arangodb extension; 