### PR TITLE
Update cassandra module to use JNoSQL Database Cassandra Extension 

### DIFF
--- a/arangodb/README.md
+++ b/arangodb/README.md
@@ -13,7 +13,10 @@ A JNoSQL project with Java SE using Document API with ArangoDB as driver impleme
 
 Once this a communication layer to ArangoDB, we're using integration test, so you need to install ArangoDB. The recommended way is using Docker.
 
+## Using Docker
+
 ![Docker](https://d1q6f0aelx0por.cloudfront.net/product-logos/library-docker-logo.png)
+
 
 
 1. Install docker: https://www.docker.com/
@@ -22,7 +25,7 @@ Once this a communication layer to ArangoDB, we're using integration test, so yo
     ```console
     docker run -e ARANGO_NO_AUTH=1 -d --name arangodb-instance -p 8529:8529 -d arangodb/arangodb
     ```
-1. Execute the test 
-    ```console
-    mvn clean install
-    ```
+
+## Run the code
+
+With a ArangoDB instance running go to the classes **App** and have fun.

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -7,7 +7,7 @@ An Artemis project with Java SE using using Column API with Cassandra as driver 
 **Cassandra**: Apache Cassandra is a free and open-source distributed database management system designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure.
 
 
-To run this project a Cassandra instance is required, so you can use either a local instalation or using Docker.
+To run this project a Cassandra instance is required, so you can use either a local installation or using Docker.
 
 
 ## Manual installation
@@ -17,15 +17,15 @@ Follow the instructions in: http://cassandra.apache.org/doc/latest/getting_start
 
 ## Using Docker
 
-![Docker](https://www.docker.com/sites/default/files/horizontal_large.png)
+![Docker](https://d1q6f0aelx0por.cloudfront.net/product-logos/library-docker-logo.png)
 
 
 1. Install docker: https://www.docker.com/
 1. https://store.docker.com/images/cassandra
 1. Run docker command
-1. `docker run -d --name casandra-instance -p 9042:9042 cassandra`
-
-
+    ```console
+    docker run -d --name casandra-instance -p 9042:9042 cassandra
+    ```
 
 ## Run the code
 

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -23,14 +23,15 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jnosql.version>1.0.0-SNAPSHOT</jnosql.version>
     </properties>
 
     <dependencies>
 
         <dependency>
-            <groupId>org.eclipse.jnosql.mapping</groupId>
-            <artifactId>jnosql-cassandra-extension</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.eclipse.jnosql.databases</groupId>
+            <artifactId>jnosql-cassandra</artifactId>
+            <version>${jnosql.version}</version>
         </dependency>
     </dependencies>
 

--- a/cassandra/src/main/java/org/jnosql/demo/se/App.java
+++ b/cassandra/src/main/java/org/jnosql/demo/se/App.java
@@ -15,7 +15,7 @@ package org.jnosql.demo.se;
 import jakarta.enterprise.inject.se.SeContainer;
 import jakarta.enterprise.inject.se.SeContainerInitializer;
 import jakarta.nosql.column.ColumnTemplate;
-import org.eclipse.jnosql.mapping.cassandra.column.CassandraTemplate;
+import org.eclipse.jnosql.databases.cassandra.mapping.CassandraTemplate;
 
 import java.util.Arrays;
 import java.util.Optional;

--- a/cassandra/src/main/java/org/jnosql/demo/se/App3.java
+++ b/cassandra/src/main/java/org/jnosql/demo/se/App3.java
@@ -15,7 +15,7 @@ package org.jnosql.demo.se;
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import jakarta.enterprise.inject.se.SeContainer;
 import jakarta.enterprise.inject.se.SeContainerInitializer;
-import org.eclipse.jnosql.mapping.cassandra.column.CassandraTemplate;
+import org.eclipse.jnosql.databases.cassandra.mapping.CassandraTemplate;
 
 import java.util.Arrays;
 import java.util.List;

--- a/cassandra/src/main/java/org/jnosql/demo/se/App5.java
+++ b/cassandra/src/main/java/org/jnosql/demo/se/App5.java
@@ -11,7 +11,7 @@
 package org.jnosql.demo.se;
 
 
-import org.eclipse.jnosql.mapping.cassandra.column.CassandraTemplate;
+import org.eclipse.jnosql.databases.cassandra.mapping.CassandraTemplate;
 
 import jakarta.enterprise.inject.se.SeContainer;
 import jakarta.enterprise.inject.se.SeContainerInitializer;

--- a/cassandra/src/main/java/org/jnosql/demo/se/Company.java
+++ b/cassandra/src/main/java/org/jnosql/demo/se/Company.java
@@ -13,7 +13,7 @@ package org.jnosql.demo.se;
 import jakarta.nosql.Column;
 import jakarta.nosql.Entity;
 import jakarta.nosql.Id;
-import org.eclipse.jnosql.mapping.cassandra.column.UDT;
+import org.eclipse.jnosql.databases.cassandra.mapping.UDT;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/cassandra/src/main/java/org/jnosql/demo/se/Movie.java
+++ b/cassandra/src/main/java/org/jnosql/demo/se/Movie.java
@@ -14,7 +14,7 @@ package org.jnosql.demo.se;
 
 import jakarta.nosql.Column;
 import jakarta.nosql.Entity;
-import org.eclipse.jnosql.mapping.cassandra.column.UDT;
+import org.eclipse.jnosql.databases.cassandra.mapping.UDT;
 
 import java.util.Objects;
 

--- a/cassandra/src/main/java/org/jnosql/demo/se/MovieRepository.java
+++ b/cassandra/src/main/java/org/jnosql/demo/se/MovieRepository.java
@@ -13,8 +13,8 @@ package org.jnosql.demo.se;
 
 
 import jakarta.data.repository.Repository;
-import org.eclipse.jnosql.mapping.cassandra.column.CQL;
-import org.eclipse.jnosql.mapping.cassandra.column.CassandraRepository;
+import org.eclipse.jnosql.databases.cassandra.mapping.CQL;
+import org.eclipse.jnosql.databases.cassandra.mapping.CassandraRepository;
 
 import java.util.List;
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,15 @@
         </plugins>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven.compile.version}</version>
+                    <configuration>
+                        <target>${maven.compiler.target}</target>
+                        <source>${maven.compiler.source}</source>
+                    </configuration>
+                </plugin>
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>


### PR DESCRIPTION
Ref.: https://github.com/eclipse/jnosql/issues/365

## Changes
- Update REAME.md from cassandra module;
- Update cassandra module to use JNoSQL Database Cassandra Extension; 
- Add `maven-compiler-plugin` to POM.xml