### PR TITLE
Update `mongodb-double` module to use JNosql Database MongoDB Implementation

### DIFF
--- a/mongodb-double/pom.xml
+++ b/mongodb-double/pom.xml
@@ -27,14 +27,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.jnosql.mapping</groupId>
-            <artifactId>jnosql-mapping-document</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jnosql.communication</groupId>
-            <artifactId>jnosql-mongodb-driver</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.eclipse.jnosql.databases</groupId>
+            <artifactId>jnosql-mongodb</artifactId>
+            <version>${jnosql.version}</version>
         </dependency>
     </dependencies>
 

--- a/mongodb-double/src/main/java/org/jnosql/demo/se/ManagerProducer.java
+++ b/mongodb-double/src/main/java/org/jnosql/demo/se/ManagerProducer.java
@@ -17,7 +17,7 @@ import org.eclipse.jnosql.communication.Settings;
 import org.eclipse.jnosql.communication.document.DocumentConfiguration;
 import org.eclipse.jnosql.communication.document.DocumentManager;
 import org.eclipse.jnosql.communication.document.DocumentManagerFactory;
-import org.eclipse.jnosql.communication.mongodb.document.MongoDBDocumentConfiguration;
+import org.eclipse.jnosql.databases.mongodb.communication.MongoDBDocumentConfiguration;
 import org.eclipse.jnosql.mapping.Database;
 import org.eclipse.jnosql.mapping.DatabaseType;
 import org.eclipse.jnosql.mapping.config.MicroProfileSettings;


### PR DESCRIPTION
Ref: https://github.com/eclipse/jnosql/issues/365

## Changes
- Added Jakarta NoSQL Database MongoDB implementation as a dependency into `mongodb-double` POM.xml;
- Fixed package imports in the `mongodb-double` classes; 