### PR TITLE
Applied the Jakarta big-bang (`javax.*` to `jakarta.*`) to the `bean-validation` module

### DIFF
--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -23,14 +23,15 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jnosql.version>1.0.0-SNAPSHOT</jnosql.version>
+        <hibernate.validator.version>8.0.0.Final</hibernate.validator.version>
+        <jakarta.el.impl.version>5.0.0-M1</jakarta.el.impl.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.jnosql.mapping</groupId>
             <artifactId>jnosql-mapping-validation</artifactId>
-            <version>${project.version}</version>
+            <version>${jnosql.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jnosql.databases</groupId>
@@ -40,12 +41,12 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.0.16.Final</version>
+            <version>${hibernate.validator.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
-            <version>3.0.0</version>
+            <artifactId>jakarta.el</artifactId>
+            <version>${jakarta.el.impl.version}</version>
         </dependency>
         <dependency>
             <groupId>org.javamoney.moneta</groupId>

--- a/bean-validation/src/main/java/org/jnosql/demo/se/Car.java
+++ b/bean-validation/src/main/java/org/jnosql/demo/se/Car.java
@@ -23,9 +23,9 @@ import org.jnosql.demo.se.validation.MonetaryMax;
 import org.jnosql.demo.se.validation.MonetaryMin;
 
 import javax.money.MonetaryAmount;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.util.function.Supplier;
 
 @Entity

--- a/bean-validation/src/main/java/org/jnosql/demo/se/Driver.java
+++ b/bean-validation/src/main/java/org/jnosql/demo/se/Driver.java
@@ -16,18 +16,18 @@
 package org.jnosql.demo.se;
 
 import jakarta.nosql.Column;
-import org.eclipse.jnosql.databases.mongodb.mapping.ObjectIdConverter;
-import org.eclipse.jnosql.mapping.Convert;
 import jakarta.nosql.Entity;
 import jakarta.nosql.Id;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.eclipse.jnosql.databases.mongodb.mapping.ObjectIdConverter;
+import org.eclipse.jnosql.mapping.Convert;
 
-import javax.validation.constraints.AssertTrue;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;

--- a/bean-validation/src/main/java/org/jnosql/demo/se/converter/MonetaryAmountConverter.java
+++ b/bean-validation/src/main/java/org/jnosql/demo/se/converter/MonetaryAmountConverter.java
@@ -75,8 +75,8 @@ public class MonetaryAmountConverter implements AttributeConverter<MonetaryAmoun
 
     private MonetaryAmount getMonetaryAmount(Document document) {
 
-        Map<String,Value> attributes = document.value().get(new TypeReference<List<Document>>() {
-                })
+        Map<String,Value> attributes = document.value()
+                .get(new TypeReference<List<Document>>() {})
                 .stream()
                 .map(d -> Map.of(d.name(), d.value()))
                 .reduce(new HashMap<>(), (a, b) -> {

--- a/bean-validation/src/main/java/org/jnosql/demo/se/converter/MonetaryAmountConverter.java
+++ b/bean-validation/src/main/java/org/jnosql/demo/se/converter/MonetaryAmountConverter.java
@@ -75,7 +75,7 @@ public class MonetaryAmountConverter implements AttributeConverter<MonetaryAmoun
 
     private MonetaryAmount getMonetaryAmount(Document document) {
 
-        Map<String, Value> attributes = document.value().get(new TypeReference<List<Document>>() {
+        Map<String,Value> attributes = document.value().get(new TypeReference<List<Document>>() {
                 })
                 .stream()
                 .map(d -> Map.of(d.name(), d.value()))
@@ -85,8 +85,7 @@ public class MonetaryAmountConverter implements AttributeConverter<MonetaryAmoun
                 });
 
         String currency = Optional.ofNullable(attributes.get(CURRENCY))
-                .map(Value::get)
-                .map(String::valueOf)
+                .map(v -> v.get(String.class))
                 .orElse(DEFAULT_CURRENCY);
 
         BigDecimal value = Optional.ofNullable(attributes.get(VALUE))

--- a/bean-validation/src/main/java/org/jnosql/demo/se/validation/CurrencyAccepted.java
+++ b/bean-validation/src/main/java/org/jnosql/demo/se/validation/CurrencyAccepted.java
@@ -24,8 +24,8 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 
 @Target( { METHOD, FIELD, ANNOTATION_TYPE })
 @Retention(RUNTIME)

--- a/bean-validation/src/main/java/org/jnosql/demo/se/validation/MonetaryAmountAcceptedValidator.java
+++ b/bean-validation/src/main/java/org/jnosql/demo/se/validation/MonetaryAmountAcceptedValidator.java
@@ -17,8 +17,8 @@ package org.jnosql.demo.se.validation;
 
 import javax.money.CurrencyUnit;
 import javax.money.MonetaryAmount;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/bean-validation/src/main/java/org/jnosql/demo/se/validation/MonetaryAmountMaxValidator.java
+++ b/bean-validation/src/main/java/org/jnosql/demo/se/validation/MonetaryAmountMaxValidator.java
@@ -15,8 +15,8 @@
 package org.jnosql.demo.se.validation;
 
 import javax.money.MonetaryAmount;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import java.math.BigDecimal;
 
 public class MonetaryAmountMaxValidator implements ConstraintValidator<MonetaryMax, MonetaryAmount>{

--- a/bean-validation/src/main/java/org/jnosql/demo/se/validation/MonetaryAmountMinValidator.java
+++ b/bean-validation/src/main/java/org/jnosql/demo/se/validation/MonetaryAmountMinValidator.java
@@ -15,8 +15,8 @@
 package org.jnosql.demo.se.validation;
 
 import javax.money.MonetaryAmount;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import java.math.BigDecimal;
 
 public class MonetaryAmountMinValidator implements ConstraintValidator<MonetaryMin, MonetaryAmount>{

--- a/bean-validation/src/main/java/org/jnosql/demo/se/validation/MonetaryMax.java
+++ b/bean-validation/src/main/java/org/jnosql/demo/se/validation/MonetaryMax.java
@@ -24,8 +24,8 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 
 @Target( { METHOD, FIELD, ANNOTATION_TYPE })
 @Retention(RUNTIME)

--- a/bean-validation/src/main/java/org/jnosql/demo/se/validation/MonetaryMin.java
+++ b/bean-validation/src/main/java/org/jnosql/demo/se/validation/MonetaryMin.java
@@ -24,8 +24,8 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 
 @Target( { METHOD, FIELD, ANNOTATION_TYPE })
 @Retention(RUNTIME)

--- a/bean-validation/src/test/java/org/jnosql/demo/se/CarTest.java
+++ b/bean-validation/src/test/java/org/jnosql/demo/se/CarTest.java
@@ -14,16 +14,17 @@
  */
 package org.jnosql.demo.se;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import org.javamoney.moneta.Money;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import javax.money.CurrencyUnit;
 import javax.money.Monetary;
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
+
 import java.util.Locale;
 import java.util.Set;
 
@@ -39,8 +40,9 @@ class CarTest {
 
     @BeforeAll
     public static void setUp() {
-        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
-        validator = factory.getValidator();
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            validator = factory.getValidator();
+        }
     }
 
 

--- a/bean-validation/src/test/java/org/jnosql/demo/se/DriverTest.java
+++ b/bean-validation/src/test/java/org/jnosql/demo/se/DriverTest.java
@@ -14,6 +14,10 @@
  */
 package org.jnosql.demo.se;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import org.javamoney.moneta.Money;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,15 +25,13 @@ import org.junit.jupiter.api.Test;
 
 import javax.money.CurrencyUnit;
 import javax.money.Monetary;
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DriverTest {
 
@@ -49,8 +51,9 @@ class DriverTest {
 
     @BeforeAll
     public static void beforeAll() {
-        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
-        validator = factory.getValidator();
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            validator = factory.getValidator();
+        }
     }
 
 

--- a/bean-validation/src/test/java/org/jnosql/demo/se/validation/MonetaryAmountAcceptedValidatorTest.java
+++ b/bean-validation/src/test/java/org/jnosql/demo/se/validation/MonetaryAmountAcceptedValidatorTest.java
@@ -25,11 +25,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.money.Monetary;
 import javax.money.MonetaryAmount;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 
 import java.util.Locale;
 import java.util.Set;

--- a/bean-validation/src/test/java/org/jnosql/demo/se/validation/MonetaryAmountMaxValidatorTest.java
+++ b/bean-validation/src/test/java/org/jnosql/demo/se/validation/MonetaryAmountMaxValidatorTest.java
@@ -25,11 +25,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.money.Monetary;
 import javax.money.MonetaryAmount;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 
 import java.util.Set;
 

--- a/bean-validation/src/test/java/org/jnosql/demo/se/validation/MonetaryAmountMinValidatorTest.java
+++ b/bean-validation/src/test/java/org/jnosql/demo/se/validation/MonetaryAmountMinValidatorTest.java
@@ -14,6 +14,11 @@
  */
 package org.jnosql.demo.se.validation;
 
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import org.javamoney.moneta.Money;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -25,11 +30,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.money.Monetary;
 import javax.money.MonetaryAmount;
-import javax.validation.ConstraintValidatorContext;
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compile.version>3.5.1</maven.compile.version>
+        <maven-surefire-plugin.version>3.1.0</maven-surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jakarta.json.bind.version>3.0.0</jakarta.json.bind.version>
         <jakarta.json.version>2.1.1</jakarta.json.version>
@@ -119,6 +120,11 @@
                         <target>${maven.compiler.target}</target>
                         <source>${maven.compiler.source}</source>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
                 </plugin>
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
                 <plugin>


### PR DESCRIPTION
Ref: https://github.com/eclipse/jnosql/issues/365

## Changes
- Applied the Jakarta big-bang (`javax.*` to `jakarta.*`) to the source;
- Updated maven-surefire-plugin version to 3.1.0;
- Fixed `MonetaryAmountConverter` logic;