### PR TITLE
Update `elasticsearch` module to use the JNoSQL Database Elasticsearch Implementation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -133,7 +133,11 @@ image::https://d1q6f0aelx0por.cloudfront.net/product-logos/library-docker-logo.p
 [source, bash]
 ----
 
-docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" elasticsearch:7.17.7
+docker run -p 9200:9200 -p 9300:9300 \
+  -e "ES_JAVA_OPTS=-Xms1g -Xmx1g" \
+  -e "xpack.security.enabled=false" \
+  -e "discovery.type=single-node" \
+  elasticsearch:8.7.1
 ----
 
 ==== Projects

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -27,9 +27,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.jnosql.mapping</groupId>
-            <artifactId>jnosql-elasticsearch-extension</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.eclipse.jnosql.databases</groupId>
+            <artifactId>jnosql-elasticsearch</artifactId>
+            <version>${jnosql.version}</version>
         </dependency>
     </dependencies>
 

--- a/elasticsearch/src/main/java/org/jnosql/demo/se/App.java
+++ b/elasticsearch/src/main/java/org/jnosql/demo/se/App.java
@@ -52,7 +52,7 @@ public class App {
             DocumentQuery query = select().from("developer")
                     .where("_id").eq(id).build();
 
-            Optional<Developer> optional = template.select(Developer.class).where("")
+            Optional<Developer> optional = template.select(Developer.class).where("id")
                     .eq(id).singleResult();
             System.out.println("Entity found: " + optional);
 

--- a/elasticsearch/src/main/java/org/jnosql/demo/se/App2.java
+++ b/elasticsearch/src/main/java/org/jnosql/demo/se/App2.java
@@ -12,18 +12,19 @@
 package org.jnosql.demo.se;
 
 
-import org.eclipse.jnosql.mapping.DatabaseQualifier;
-
 import jakarta.enterprise.inject.se.SeContainer;
 import jakarta.enterprise.inject.se.SeContainerInitializer;
+import org.eclipse.jnosql.mapping.DatabaseQualifier;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 public class App2 {
 
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws InterruptedException {
 
         Random random = new Random();
         long id = random.nextLong();
@@ -45,6 +46,9 @@ public class App2 {
             DeveloperRepository repository = container.select(DeveloperRepository.class)
                     .select(DatabaseQualifier.ofDocument()).get();
             repository.save(developer);
+
+            // it's needed 'cause the cluster indexing requires a little delay
+            TimeUnit.SECONDS.sleep(2);
 
             List<Developer> people = repository.findByName("Maria Lovelace");
             System.out.println("Entity found: " + people);

--- a/elasticsearch/src/main/java/org/jnosql/demo/se/DeveloperRepository.java
+++ b/elasticsearch/src/main/java/org/jnosql/demo/se/DeveloperRepository.java
@@ -20,6 +20,8 @@ import java.util.List;
 @Repository
 public interface DeveloperRepository extends CrudRepository<Developer, Long> {
 
-
+    // It's necessary to make sure that
+    // the 'name' field is mapped as `keyword`
+    // in the mappings of the index (that is our the 'developers' db)
     List<Developer> findByName(String name);
 }

--- a/elasticsearch/src/main/resources/developers.json
+++ b/elasticsearch/src/main/resources/developers.json
@@ -1,0 +1,12 @@
+{
+  "mappings": {
+    "properties": {
+      "@entity": {
+        "type": "keyword"
+      },
+      "names": {
+        "type": "keyword"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Ref: https://github.com/eclipse/jnosql/issues/365

## Changes
- Updated the `elasticsearch` module to use the JNoSQL Database Elasticsearch Implementation;
- Fixed classes to work as expected;
- Added `developers.json` file in order to make the queries in the `App` classes work as expected;