### PR TITLE
Chore: update version to use jnosql version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -259,7 +259,7 @@ image::https://d1q6f0aelx0por.cloudfront.net/product-logos/library-docker-logo.p
 
 [source, bash]
 ----
-docker run --publish=7474:7474 --publish=7687:7687 --env NEO4J_AUTH=neo4j/admin neo4j
+docker run --publish=7474:7474 --publish=7687:7687 --env NEO4J_AUTH=neo4j/admin123 neo4j
 ----
 
 ==== Projects

--- a/neo4j/pom.xml
+++ b/neo4j/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.eclipse.jnosql.mapping</groupId>
             <artifactId>jnosql-graph-connections</artifactId>
-            <version>${project.version}</version>
+            <version>${jnosql.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>

--- a/neo4j/src/main/resources/META-INF/microprofile-config.properties
+++ b/neo4j/src/main/resources/META-INF/microprofile-config.properties
@@ -11,5 +11,5 @@
 
 jnosql.neo4j.host=bolt://localhost:7687
 jnosql.neo4j.user=neo4j
-jnosql.neo4j.password=admin
+jnosql.neo4j.password=admin123
 jnosql.graph.provider=org.eclipse.jnosql.mapping.graph.connections.Neo4JGraphConfiguration


### PR DESCRIPTION
Ref [eclipse/jnosql#365](https://github.com/eclipse/jnosql/issues/365)

Fix: Docker docs and password on microprofile-config.properties. Now neo4j ask for a 8 characteres mininum password to launch DB. 

Everything else is still working. 



Signed-off-by: Bruno Barros brunog.barros@proton.me